### PR TITLE
Ajout du bouton revenir à la recherche

### DIFF
--- a/prosopapp/app/templates/pages/resultats_avances.html
+++ b/prosopapp/app/templates/pages/resultats_avances.html
@@ -51,9 +51,10 @@
         {%- endfor %}
       </ul>
     </nav>
+            <div class = "container" style="padding-bottom: 5%; text-align:center">
+    <a class="btn btn-primary" href="{{ url_for('recherche') }}">Faire une nouvelle recherche</a>
+</div>
     {% endif %}
-    </div>
-
     </div>
 
 {% endblock %}


### PR DESCRIPTION
Ajout d'un petit bouton pour revenir à la page d'accueil du formulaire de recherche avancée.
Cette précaution vise à rendre la navigation plus fluide pour que l'utilisateur puisse revenir sur une page recherche avancée vierge (lorsqu'on retourne en arrière avec le bouton du navigateur, cela garde en mémoire les informations préalablement rentrées et cela peut créer des conflits).